### PR TITLE
feat: add ability to change recipient (in case of key loss)

### DIFF
--- a/contracts/VestingEscrowSimple.vy
+++ b/contracts/VestingEscrowSimple.vy
@@ -24,6 +24,11 @@ event Rug:
 event AdminSet:
     admin: address
 
+event RecipientTransferInitiated:
+    recipient: address
+
+event RecipientTransferFinalized:
+    recipient: address
 
 recipient: public(address)
 token: public(ERC20)
@@ -35,6 +40,10 @@ disabled_at: public(uint256)
 
 admin: public(address)
 future_admin: public(address)
+
+pending_recipient: public(address)
+recipient_transfer_started: public(uint256)
+ONE_WEEK: constant(uint256) = 604_800  # 1 week (in seconds)
 
 @external
 def __init__():
@@ -132,7 +141,7 @@ def claim(amount: uint256 = MAX_UINT256, recipient: address = msg.sender):
         t = block.timestamp
     claimable: uint256 = min(self._total_vested_at(t) - self.total_claimed, amount)
     self.total_claimed += claimable
-    
+
     assert self.token.transfer(recipient, claimable)
     log Claim(recipient, claimable)
 
@@ -161,3 +170,26 @@ def set_admin(admin: address):
     assert msg.sender == self.admin  # dev: admin only
     self.admin = admin
     log AdminSet(admin)
+
+
+@external
+def set_recipient(recipient: address):
+    """
+    @notice Start transfer of escrow benefits to another address
+    @param recipient Address to have escrow benefits transferred to
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    self.pending_recipient = recipient
+    self.recipient_transfer_started = block.timestamp
+    log RecipientTransferInitiated(recipient)
+
+
+@external
+def accept_recipient():
+    """
+    @notice Complete transfer of escrow benefits to another address
+    """
+    assert block.timestamp >= self.recipient_transfer_started  + ONE_WEEK  # dev: action not ready
+    assert msg.sender == self.pending_recipient  # dev: recipient only
+    self.recipient = msg.sender
+    log RecipientTransferFinalized(msg.sender)


### PR DESCRIPTION
This PR adds the ability for the `admin` to change the `recipient`, in case they lose access to their claiming keys, or a number of other reasons why they might not be able to call claim anymore.

This has similiar security properties as `rug_pull` for the `recipient` role, with the added benefit of not losing access to what they have already been vested when `rug_pull` gets called. However, this method can be abused by the `admin` to steal more funds than what `rug_pull` can do, so a 1 week delay is added to prevent governance from being able to take more than what they can get from `rug_pull`.