### PR TITLE
docs: restore deployment history

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,31 +76,33 @@ Production deployment requires an independent audit, a reviewed deployment
 manifest, source verification, and low-value standard-token and ERC-4626
 canaries.
 
+## Escrow manager
+
+Wavey's [Vesting Escrow app](https://vest.wavey.info/) provides an interface to
+find and manage escrows deployed by the current Yearn factory and the LlamaPay
+v2 factory. The app and its Ethereum event indexer are
+[open source](https://github.com/wavey0x/vesting-escrow-app).
+
 ## Production deployments
 
 The `version() == 2` contracts on `master` have not yet been deployed or
 audited. This contract version is separate from the historical v0.x release
 tags below. Existing factories and escrows remain immutable and unaffected.
 
-The [Vesting Escrow app](https://vest.wavey.info/) indexes escrows from the
-current Yearn factory and a compatible Curve deployment. Its
-[source and indexer](https://github.com/wavey0x/vesting-escrow-app) track both
-factories. Older Yearn deployments are listed below for historical reference
-but are not indexed by the app.
-
 ### [v0.3.0](https://github.com/yearn/yearn-vesting-escrow/tree/v0.3.0)
 
-This is the current Yearn factory used by the app's create flow.
+This is the current Yearn factory.
 
 - Factory: [`0x200C92Dd85730872Ab6A1e7d5E40A067066257cF`](https://etherscan.io/address/0x200c92dd85730872ab6a1e7d5e40a067066257cf#code)
 - Implementation: [`0x9692F652A3048eb7F5074e12B907F20d33F37a01`](https://etherscan.io/address/0x9692f652a3048eb7f5074e12b907f20d33f37a01#code)
 - Audit: [MixBytes, 2023-10-13](https://github.com/yearn/yearn-security/tree/master/audits/20231013_Mixbytes_yearn_vesting_escrow)
 
-### Compatible Curve deployment
+### [LlamaPay v2](https://github.com/LlamaPay/yearn-vesting-escrow) (derived from v0.3.0)
 
-The app also indexes this production deployment. It preserves the v0.3.0
-consumer interface while adding an escrow registry and several hardening
-changes.
+LlamaPay forked this repository at
+[v0.3.0 (`d14eed1`)](https://github.com/yearn/yearn-vesting-escrow/commit/d14eed16f5b131bc35c58df2b8b4a03427928ef1)
+and retained its consumer interface. Its v2 adds an escrow registry, makes the
+Vyper donation opt-in by default, and hardens revoke and dust handling.
 
 - Factory: [`0xcf61782465Ff973638143d6492B51A85986aB347`](https://etherscan.io/address/0xcf61782465ff973638143d6492b51a85986ab347#code)
 - Implementation: [`0x9dd5cF263327e2D6a608da8c30368Eb27514bAD2`](https://etherscan.io/address/0x9dd5cf263327e2d6a608da8c30368eb27514bad2#code)

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 Vesting escrows for standard ERC-20 tokens and optional ERC-4626 vault-share
 principal accounting.
 
-The unreleased version 2 contracts preserve the version 1 lifecycle while
-adding an opt-in `yield_to_owner` mode:
+The unreleased version 2 contracts preserve the deployed v0.3.0 lifecycle
+while adding an opt-in `yield_to_owner` mode:
 
 - funding and payouts remain in the supplied ERC-20 token;
 - in yield mode that token is an ERC-4626 wrapper share;
@@ -76,12 +76,46 @@ Production deployment requires an independent audit, a reviewed deployment
 manifest, source verification, and low-value standard-token and ERC-4626
 canaries.
 
-## Deployed version 1
+## Production deployments
 
-The audited version 1 contracts remain immutable and unaffected:
+The `version() == 2` contracts on `master` have not yet been deployed or
+audited. This contract version is separate from the historical v0.x release
+tags below. Existing factories and escrows remain immutable and unaffected.
+
+The [Vesting Escrow app](https://vest.wavey.info/) indexes escrows from the
+current Yearn factory and a compatible Curve deployment. Its
+[source and indexer](https://github.com/wavey0x/vesting-escrow-app) track both
+factories. Older Yearn deployments are listed below for historical reference
+but are not indexed by the app.
+
+### [v0.3.0](https://github.com/yearn/yearn-vesting-escrow/tree/v0.3.0)
+
+This is the current Yearn factory used by the app's create flow.
 
 - Factory: [`0x200C92Dd85730872Ab6A1e7d5E40A067066257cF`](https://etherscan.io/address/0x200c92dd85730872ab6a1e7d5e40a067066257cf#code)
 - Implementation: [`0x9692F652A3048eb7F5074e12B907F20d33F37a01`](https://etherscan.io/address/0x9692f652a3048eb7f5074e12b907f20d33f37a01#code)
 - Audit: [MixBytes, 2023-10-13](https://github.com/yearn/yearn-security/tree/master/audits/20231013_Mixbytes_yearn_vesting_escrow)
 
-Version 2 has not yet been deployed or audited.
+### Compatible Curve deployment
+
+The app also indexes this production deployment. It preserves the v0.3.0
+consumer interface while adding an escrow registry and several hardening
+changes.
+
+- Factory: [`0xcf61782465Ff973638143d6492B51A85986aB347`](https://etherscan.io/address/0xcf61782465ff973638143d6492b51a85986ab347#code)
+- Implementation: [`0x9dd5cF263327e2D6a608da8c30368Eb27514bAD2`](https://etherscan.io/address/0x9dd5cf263327e2d6a608da8c30368eb27514bad2#code)
+
+### [v0.2.0](https://github.com/yearn/yearn-vesting-escrow/tree/v0.2.0)
+
+- Factory: [`0x98d3872b4025ABE58C4667216047Fe549378d90f`](https://etherscan.io/address/0x98d3872b4025abe58c4667216047fe549378d90f#code)
+- Implementation: [`0xaB080A16007DC2E34b99F269a0217B4e96f88813`](https://etherscan.io/address/0xab080a16007dc2e34b99f269a0217b4e96f88813#code)
+
+### [v0.1.0](https://github.com/yearn/yearn-vesting-escrow/tree/v0.1.0)
+
+> [!WARNING]
+> This version has an
+> [unpatched bug](https://github.com/banteg/yearn-vesting-escrow/security/advisories/GHSA-vpxq-238p-8q3m).
+> Do not call `renounce_ownership`.
+
+- Factory: [`0xF124534bfa6Ac7b89483B401B4115Ec0d27cad6A`](https://etherscan.io/address/0xf124534bfa6ac7b89483b401b4115ec0d27cad6a#code)
+- Implementation: [`0x9c351CabC5d9e1393678d221F84E6EE3D05c016F`](https://etherscan.io/address/0x9c351cabc5d9e1393678d221f84e6ee3d05c016f#code)


### PR DESCRIPTION
## Summary

- clarify that the unreleased `version() == 2` contracts are distinct from the historical v0.x release tags
- restore the v0.1.0, v0.2.0, and audited v0.3.0 Ethereum mainnet deployment addresses
- retain the v0.1.0 `renounce_ownership` warning
- link Wavey's vesting app/indexer and document the LlamaPay v2 production factory it tracks
- identify LlamaPay v2 as a fork of the exact Yearn v0.3.0 release commit

## Why

The README rewrite in #24 collapsed the deployed history into a single “version 1” entry. That terminology is ambiguous now that the contracts expose a numeric `version()` getter, and it removed still-useful provenance for the earlier immutable mainnet deployments.

## Impact

Readers can distinguish the upcoming v2 contracts from the existing tagged releases and find every historical Yearn deployment, while also seeing which current factories the vesting app indexes.

## Validation

- `git diff --check`
- confirmed the v0.1.0, v0.2.0, and v0.3.0 tags locally
- confirmed bytecode exists at every listed factory and implementation address using the local Ethereum mainnet archive node
- cross-checked the current Yearn and LlamaPay factory/implementation addresses against Wavey's app indexer and LlamaPay's repositories
